### PR TITLE
libusb interop header refactoring, method list update, badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 .DS_Store
 *.suo
 *.user
+
+# DNX
+project.lock.json
+artifacts/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LibUsbDotNet
 [![Build status](https://ci.appveyor.com/api/projects/status/5fe0th33i60h24bw?svg=true)](https://ci.appveyor.com/project/qmfrederik/libusbdotnet)
+![NuGet version](https://img.shields.io/nuget/v/CoreCompat.LibUsbDotNet.svg)
 
 > __NOTE__ This repository contains a fork of LibUsbDotNet; the original repository is located on [SourceForge](https://sourceforge.net/p/libusbdotnet/).
 > This repository adds some minor bug fixes and support for .NET Core.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LibUsbDotNet
 [![Build status](https://ci.appveyor.com/api/projects/status/5fe0th33i60h24bw?svg=true)](https://ci.appveyor.com/project/qmfrederik/libusbdotnet)
 ![NuGet version](https://img.shields.io/nuget/v/CoreCompat.LibUsbDotNet.svg)
+![LGPLv3 license](https://img.shields.io/github/license/andrasfuchs/libusbdotnet.svg)
 
 > __NOTE__ This repository contains a fork of LibUsbDotNet; the original repository is located on [SourceForge](https://sourceforge.net/p/libusbdotnet/).
 > This repository adds some minor bug fixes and support for .NET Core.

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -123,6 +123,9 @@
     <Compile Include="Main\UsbCtrlFlags.cs" />
     <Compile Include="Main\UsbEndpointDirection.cs" />
     <Compile Include="Main\UsbRequestRecipient.cs" />
+    <Compile Include="MonoLibUsb\MonoUsbVersion.cs" />
+    <Compile Include="MonoLibUsb\MonoLibUsbApiHelpers.cs" />
+    <Compile Include="MonoLibUsb\MonoUsbCapability.cs" />
     <Compile Include="MonoLibUsb\Profile\PollfdItem.cs" />
     <Compile Include="MonoLibUsb\Profile\AddRemoveEventArgs.cs" />
     <Compile Include="MonoLibUsb\CallbackDelegates.cs" />

--- a/stage/LibUsbDotNet/LibUsbDotNet.nuget.targets
+++ b/stage/LibUsbDotNet/LibUsbDotNet.nuget.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
+    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
+  </Target>
+</Project>

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -73,9 +73,30 @@ namespace MonoLibUsb
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_set_debug")]
         public static extern void SetDebug([In]MonoUsbSessionHandle sessionHandle, int level);
 
+        /// <summary>
+        /// Returns a struct  with the version (major, minor, micro, nano and rc) of the running library.
+        /// </summary>
+        /// <returns></returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_version")]
+        public static extern MonoUsbVersion GetVersion();
+
+        /// <summary>
+        /// Check at runtime if the loaded library has a given capability. This call should be performed after \ref libusb_init(), to ensure the backend has updated its capability set.
+        /// </summary>
+        /// <param name="capability"></param>
+        /// <returns></returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_has_capability")]
+        public static extern int HasCapability(MonoUsbCapability capability);
+
         #endregion
 
         #region API LIBRARY FUNCTIONS - Error Handling
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_error_name")]
+        public static extern string ErrorName(int errcode);
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_setlocale")]
+        public static extern int SetLocale(string locale);
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_strerror")]
         private static extern IntPtr StrError(int errcode);

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -1,7 +1,8 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright © 2006-2010 Travis Robinson <libusbdotnet@gmail.com>
+// Copyright © 2017 Andras Fuchs <andras.fuchs@gmail.com>
 // 
-// website: http://sourceforge.net/projects/libusbdotnet
-// e-mail:  libusbdotnet@gmail.com
+// Website: http://sourceforge.net/projects/libusbdotnet
+// GitHub repo: https://github.com/CoreCompat/LibUsbDotNet
 // 
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
@@ -20,46 +21,37 @@
 // 
 // 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-using LibUsbDotNet.Descriptors;
-using LibUsbDotNet.Main;
 using MonoLibUsb.Descriptors;
 using MonoLibUsb.Profile;
-using MonoLibUsb.Transfer;
-using System.Threading;
 
 namespace MonoLibUsb
 {
     /// <summary>
     /// Libusb-1.0 low-level API library.
     /// </summary>
-    public static class MonoUsbApi
+    public static partial class MonoUsbApi
     {
         internal const CallingConvention CC = 0;
         internal const string LIBUSB_DLL = "libusb-1.0.dll";
-        internal const int LIBUSB_PACK = 0;
 
-        #region Private Members
-
-        private static readonly MonoUsbTransferDelegate DefaultAsyncDelegate = DefaultAsyncCB;
-        private static void DefaultAsyncCB(MonoUsbTransfer transfer)
-        {
-            ManualResetEvent completeEvent = GCHandle.FromIntPtr(transfer.PtrUserData).Target as ManualResetEvent;
-            completeEvent.Set();
-        }
-
-        #endregion
         #region API LIBRARY FUNCTIONS - Initialization & Deinitialization
 
-
+        /// <summary>
+        /// Initialize libusb. This function must be called before calling any other libusb function.
+        /// If you do not provide an output location for a context pointer, a default context will be created. If there was already a default context, it will be reused (and nothing will be initialized/reinitialized).
+        /// </summary>
+        /// <param name="pContext">Optional output location for context pointer. Only valid on return code 0.</param>
+        /// <returns>0 on success, or a LIBUSB_ERROR code on failure</returns>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_init")]
         internal static extern int Init(ref IntPtr pContext);
 
+        /// <summary>
+        /// Deinitialize libusb. Should be called after closing all open devices and before your application terminates.
+        /// </summary>
+        /// <param name="pContext">the context to deinitialize, or NULL for the default context</param>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_exit")]
         internal static extern void Exit(IntPtr pContext);
-
 
         /// <summary>Set message verbosity.</summary>
         /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
@@ -83,7 +75,14 @@ namespace MonoLibUsb
 
         #endregion
 
-        #region API LIBRARY FUNCTIONS - Device handling and enumeration
+        #region API LIBRARY FUNCTIONS - Error Handling
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_strerror")]
+        private static extern IntPtr StrError(int errcode);
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Device handling and enumeration (part 1)
 
         /// <summary>
         /// Returns a list of USB devices currently attached to the system. 
@@ -101,6 +100,116 @@ namespace MonoLibUsb
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_free_device_list")]
         internal static extern void FreeDeviceList(IntPtr pHandleList, int unrefDevices);
 
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_ref_device")]
+        internal static extern IntPtr RefDevice(IntPtr pDeviceProfileHandle);
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_unref_device")]
+        internal static extern IntPtr UnrefDevice(IntPtr pDeviceProfileHandle);
+
+        /// <summary>
+        /// Determine the <see cref="MonoUsbConfigDescriptor.bConfigurationValue"/> of the currently active configuration. 
+        /// </summary>
+        /// <remarks>
+        /// <para>You could formulate your own control request to obtain this information, but this function has the advantage that it may be able to retrieve the information from operating system caches (no I/O involved).</para>
+        /// <para>If the OS does not cache this information, then this function will block while a control transfer is submitted to retrieve the information.</para>
+        /// <para>This function will return a value of 0 in the <paramref name="configuration"/> parameter if the device is in unconfigured state.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A device handle.</param>
+        /// <param name="configuration">Output location for the <see cref="MonoUsbConfigDescriptor.bConfigurationValue"/> of the active configuration. (only valid for return code 0)</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success</item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failure</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_configuration")]
+        public static extern int GetConfiguration([In] MonoUsbDeviceHandle deviceHandle, ref int configuration);
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - USB descriptors
+
+        /// <summary>
+        /// Gets the standard device descriptor.
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceProfileHandle">A device profile handle.</param>
+        /// <param name="deviceDescriptor">The <see cref="MonoUsbDeviceDescriptor"/> clas that will hold the data.</param>
+        /// <returns>0 on success or a <see cref="MonoUsbError"/> code on failure.</returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_device_descriptor")]
+        public static extern int GetDeviceDescriptor([In] MonoUsbProfileHandle deviceProfileHandle, [Out] MonoUsbDeviceDescriptor deviceDescriptor);
+
+        /// <summary>
+        /// Get the USB configuration descriptor for the currently active configuration.
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceProfileHandle">A device profile handle.</param>
+        /// <param name="configHandle">A config handle.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success</item>
+        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
+        /// <item>another <see cref="MonoUsbError"/> code on error</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_active_config_descriptor")]
+        public static extern int GetActiveConfigDescriptor([In] MonoUsbProfileHandle deviceProfileHandle, [Out] out MonoUsbConfigHandle configHandle);
+
+        /// <summary>
+        /// Get a USB configuration descriptor based on its index. 
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceProfileHandle">A device profile handle.</param>
+        /// <param name="configIndex">The index of the configuration you wish to retrieve.</param>
+        /// <param name="configHandle">A config handle.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success</item>
+        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
+        /// <item>another <see cref="MonoUsbError"/> code on error</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_config_descriptor")]
+        public static extern int GetConfigDescriptor([In] MonoUsbProfileHandle deviceProfileHandle, byte configIndex, [Out] out MonoUsbConfigHandle configHandle);
+
+        /// <summary>
+        /// Get a USB configuration descriptor with a specific bConfigurationValue.
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceProfileHandle">A device profile handle.</param>
+        /// <param name="bConfigurationValue">The bConfigurationValue of the configuration you wish to retrieve.</param>
+        /// <param name="configHandle">A config handle.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success</item>
+        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
+        /// <item>another <see cref="MonoUsbError"/> code on error</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_config_descriptor_by_value")]
+        public static extern int GetConfigDescriptorByValue([In] MonoUsbProfileHandle deviceProfileHandle, byte bConfigurationValue, [Out] out MonoUsbConfigHandle configHandle);
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_free_config_descriptor")]
+        internal static extern void FreeConfigDescriptor(IntPtr pConfigDescriptor);
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Device handling and enumeration (part 2)
+
         /// <summary>
         /// Get the number of the bus that a device is connected to. 
         /// </summary>
@@ -111,7 +220,6 @@ namespace MonoLibUsb
         /// <param name="deviceProfileHandle">A device profile handle.</param>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_bus_number")]
         public static extern byte GetBusNumber([In] MonoUsbProfileHandle deviceProfileHandle);
-
 
         /// <summary>
         /// Get the address of the device on the bus it is connected to. 
@@ -152,79 +260,14 @@ namespace MonoLibUsb
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_max_iso_packet_size")]
         public static extern int GetMaxIsoPacketSize([In] MonoUsbProfileHandle deviceProfileHandle, byte endpoint);
 
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_ref_device")]
-        internal static extern IntPtr RefDevice(IntPtr pDeviceProfileHandle);
-
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_unref_device")]
-        internal static extern IntPtr UnrefDevice(IntPtr pDeviceProfileHandle);
-
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_open")]
         internal static extern int Open([In] MonoUsbProfileHandle deviceProfileHandle, ref IntPtr deviceHandle);
-
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_open_device_with_vid_pid")]
-        private static extern IntPtr OpenDeviceWithVidPidInternal([In]MonoUsbSessionHandle sessionHandle, short vendorID, short productID);
-
-        /// <summary>
-        /// Convenience function for finding a device with a particular idVendor/idProduct combination. 
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
-        /// </remarks>
-        /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
-        /// <param name="vendorID">The idVendor value to search for.</param>
-        /// <param name="productID">The idProduct value to search for.</param>
-        /// <returns>Null if the device was not opened or not found, otherwise an opened device handle.</returns>
-        public static MonoUsbDeviceHandle OpenDeviceWithVidPid([In]MonoUsbSessionHandle sessionHandle, short vendorID, short productID)
-        {
-            IntPtr pHandle = OpenDeviceWithVidPidInternal(sessionHandle, vendorID, productID);
-            if (pHandle == IntPtr.Zero) return null;
-            return new MonoUsbDeviceHandle(pHandle);
-        }
-
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_close")]
         internal static extern void Close(IntPtr deviceHandle);
 
-
-        /// <summary>
-        /// Get a <see cref="MonoUsbProfileHandle"/> for a <see cref="MonoUsbDeviceHandle"/>. 
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This function differs from the Libusb-1.0 C API in that when the new <see cref="MonoUsbProfileHandle"/> is returned, the device profile reference count 
-        /// is incremented ensuring the profile will remain valid as long as it is in-use.
-        /// </para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
-        /// </remarks>
-        /// <param name="devicehandle">A device handle.</param>
-        /// <returns>The underlying profile handle.</returns>
-        public static MonoUsbProfileHandle GetDevice(MonoUsbDeviceHandle devicehandle) { return new MonoUsbProfileHandle(GetDeviceInternal(devicehandle)); }
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_device")]
         private static extern IntPtr GetDeviceInternal([In] MonoUsbDeviceHandle devicehandle);
-
-        /// <summary>
-        /// Determine the <see cref="MonoUsbConfigDescriptor.bConfigurationValue"/> of the currently active configuration. 
-        /// </summary>
-        /// <remarks>
-        /// <para>You could formulate your own control request to obtain this information, but this function has the advantage that it may be able to retrieve the information from operating system caches (no I/O involved).</para>
-        /// <para>If the OS does not cache this information, then this function will block while a control transfer is submitted to retrieve the information.</para>
-        /// <para>This function will return a value of 0 in the <paramref name="configuration"/> parameter if the device is in unconfigured state.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A device handle.</param>
-        /// <param name="configuration">Output location for the <see cref="MonoUsbConfigDescriptor.bConfigurationValue"/> of the active configuration. (only valid for return code 0)</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success</item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failure</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_configuration")]
-        public static extern int GetConfiguration([In] MonoUsbDeviceHandle deviceHandle, ref int configuration);
 
         /// <summary>
         /// Set the active configuration for a device. 
@@ -295,6 +338,9 @@ namespace MonoLibUsb
         /// </returns>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_release_interface")]
         public static extern int ReleaseInterface([In] MonoUsbDeviceHandle deviceHandle, int interfaceNumber);
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_open_device_with_vid_pid")]
+        private static extern IntPtr OpenDeviceWithVidPidInternal([In]MonoUsbSessionHandle sessionHandle, short vendorID, short productID);
 
         /// <summary>
         /// Activate an alternate setting for an interface.
@@ -424,150 +470,130 @@ namespace MonoLibUsb
 
         #endregion
 
-        #region API LIBRARY FUNCTIONS - USB descriptors
-
-        /// <summary>
-        /// Gets the standard device descriptor.
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceProfileHandle">A device profile handle.</param>
-        /// <param name="deviceDescriptor">The <see cref="MonoUsbDeviceDescriptor"/> clas that will hold the data.</param>
-        /// <returns>0 on success or a <see cref="MonoUsbError"/> code on failure.</returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_device_descriptor")]
-        public static extern int GetDeviceDescriptor([In] MonoUsbProfileHandle deviceProfileHandle,
-                                                              [Out] MonoUsbDeviceDescriptor deviceDescriptor);
-
-        /// <summary>
-        /// Get the USB configuration descriptor for the currently active configuration.
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceProfileHandle">A device profile handle.</param>
-        /// <param name="configHandle">A config handle.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success</item>
-        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
-        /// <item>another <see cref="MonoUsbError"/> code on error</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_active_config_descriptor")]
-        public static extern int GetActiveConfigDescriptor([In] MonoUsbProfileHandle deviceProfileHandle,
-                                                                       [Out] out MonoUsbConfigHandle configHandle);
-
-
-        /// <summary>
-        /// Get a USB configuration descriptor based on its index. 
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceProfileHandle">A device profile handle.</param>
-        /// <param name="configIndex">The index of the configuration you wish to retrieve.</param>
-        /// <param name="configHandle">A config handle.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success</item>
-        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
-        /// <item>another <see cref="MonoUsbError"/> code on error</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_config_descriptor")]
-        public static extern int GetConfigDescriptor([In] MonoUsbProfileHandle deviceProfileHandle,
-                                                              byte configIndex,
-                                                              [Out] out MonoUsbConfigHandle configHandle);
-
-        /// <summary>
-        /// Get a USB configuration descriptor with a specific bConfigurationValue.
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip">This is a non-blocking function which does not involve any requests being sent to the device.</note>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceProfileHandle">A device profile handle.</param>
-        /// <param name="bConfigurationValue">The bConfigurationValue of the configuration you wish to retrieve.</param>
-        /// <param name="configHandle">A config handle.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success</item>
-        /// <item><see cref="MonoUsbError.ErrorNotFound"/> if the device is in unconfigured state </item>
-        /// <item>another <see cref="MonoUsbError"/> code on error</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_config_descriptor_by_value")]
-        public static extern int GetConfigDescriptorByValue([In] MonoUsbProfileHandle deviceProfileHandle,
-                                                                       byte bConfigurationValue,
-                                                                       [Out] out MonoUsbConfigHandle configHandle);
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_free_config_descriptor")]
-        internal static extern void FreeConfigDescriptor(IntPtr pConfigDescriptor);
-
-        /// <summary>
-        /// Retrieve a descriptor from the default control pipe. 
-        /// </summary>
-        /// <remarks>
-        /// <para>This is a convenience function which formulates the appropriate control message to retrieve the descriptor.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">Retrieve a descriptor from the default control pipe.</param>
-        /// <param name="descType">The descriptor type, <see cref="DescriptorType"/></param>
-        /// <param name="descIndex">The index of the descriptor to retrieve.</param>
-        /// <param name="pData">Output buffer for descriptor.</param>
-        /// <param name="length">Size of data buffer.</param>
-        /// <returns>Number of bytes returned in data, or a <see cref="MonoUsbError"/> code on failure.</returns>
-        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, IntPtr pData, int length)
-        {
-            return ControlTransfer(deviceHandle,
-                                           (byte) UsbEndpointDirection.EndpointIn,
-                                           (byte) UsbStandardRequest.GetDescriptor,
-                                           (short) ((descType << 8) | descIndex),
-                                           0,
-                                           pData,
-                                           (short) length,
-                                           1000);
-        }
-
-        /// <summary>
-        /// Retrieve a descriptor from the default control pipe. 
-        /// </summary>
-        /// <remarks>
-        /// <para>This is a convenience function which formulates the appropriate control message to retrieve the descriptor.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">Retrieve a descriptor from the default control pipe.</param>
-        /// <param name="descType">The descriptor type, <see cref="DescriptorType"/></param>
-        /// <param name="descIndex">The index of the descriptor to retrieve.</param>
-        /// <param name="data">Output buffer for descriptor. This object is pinned using <see cref="PinnedHandle"/>.</param>
-        /// <param name="length">Size of data buffer.</param>
-        /// <returns>Number of bytes returned in data, or <see cref="MonoUsbError"/> code on failure.</returns>
-        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, object data, int length)
-        {
-            PinnedHandle p = new PinnedHandle(data);
-            return GetDescriptor(deviceHandle, descType, descIndex, p.Handle, length);
-        }
-
-        #endregion
-
         #region API LIBRARY FUNCTIONS - Asynchronous device I/O
-
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_alloc_transfer")]
         internal static extern IntPtr AllocTransfer(int isoPackets);
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_free_transfer")]
-        internal static extern void FreeTransfer(IntPtr pTransfer);
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_submit_transfer")]
         internal static extern int SubmitTransfer(IntPtr pTransfer);
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_cancel_transfer")]
         internal static extern int CancelTransfer(IntPtr pTransfer);
+
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_free_transfer")]
+        internal static extern void FreeTransfer(IntPtr pTransfer);
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Synchronous device I/O
+
+        /// <summary>
+        /// Perform a USB control transfer.
+        /// </summary>
+        /// <remarks>
+        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
+        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="requestType">The request type field for the setup packet.</param>
+        /// <param name="request">The request field for the setup packet.</param>
+        /// <param name="value">The value field for the setup packet</param>
+        /// <param name="index">The index field for the setup packet.</param>
+        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</param>
+        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
+        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>on success, the number of bytes actually transferred</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_control_transfer")]
+        public static extern int ControlTransfer([In] MonoUsbDeviceHandle deviceHandle, byte requestType, byte request, short value, short index, IntPtr pData, short dataLength, int timeout);
+
+        /// <summary>
+        /// Perform a USB bulk transfer. 
+        /// </summary>
+        /// <remarks>
+        /// <para>The direction of the transfer is inferred from the direction bits of the endpoint address.</para>
+        /// <para>
+        /// For bulk reads, the length field indicates the maximum length of data you are expecting to receive.
+        /// If less data arrives than expected, this function will return that data, so be sure to check the 
+        /// transferred output parameter.
+        /// </para>
+        /// <para>
+        /// You should also check the transferred parameter for bulk writes. Not all of the data may have been 
+        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
+        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
+        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
+        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
+        /// of I/O.
+        /// </para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
+        /// <param name="pData">
+        /// A suitably-sized data buffer for either input or output (depending on endpoint).</param>
+        /// <param name="length">For bulk writes, the number of bytes from data to be sent. for bulk reads, the maximum number of bytes to receive into the data buffer.</param>
+        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
+        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
+        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_bulk_transfer")]
+        public static extern int BulkTransfer([In] MonoUsbDeviceHandle deviceHandle, byte endpoint, IntPtr pData, int length, out int actualLength, int timeout);
+
+        /// <summary>
+        /// Perform a USB interrupt transfer. 
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The direction of the transfer is inferred from the direction bits of the endpoint address.
+        /// </para><para>
+        /// For interrupt reads, the length field indicates the maximum length of data you are expecting to receive.
+        /// If less data arrives than expected, this function will return that data, so be sure to check the 
+        /// transferred output parameter.
+        /// </para><para>
+        /// You should also check the transferred parameter for interrupt writes. Not all of the data may have been 
+        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
+        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
+        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
+        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
+        /// of I/O.
+        /// </para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
+        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on endpoint).</param>
+        /// <param name="length">For interrupt writes, the number of bytes from data to be sent. for interrupt reads, the maximum number of bytes to receive into the data buffer.</param>
+        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
+        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
+        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_interrupt_transfer")]
+        public static extern int InterruptTransfer([In] MonoUsbDeviceHandle deviceHandle, byte endpoint, IntPtr pData, int length, out int actualLength, int timeout);
 
         #endregion
 
@@ -726,6 +752,7 @@ namespace MonoLibUsb
         /// <returns>0 on success, or a <see cref="MonoUsbError"/> code on other failure.</returns>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_handle_events")]
         public static extern int HandleEvents([In]MonoUsbSessionHandle sessionHandle);
+
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_handle_events")]
         private static extern int HandleEvents(IntPtr pSessionHandle);
 
@@ -775,6 +802,9 @@ namespace MonoLibUsb
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_next_timeout")]
         public static extern int GetNextTimeout([In]MonoUsbSessionHandle sessionHandle, ref UnixNativeTimeval tv);
 
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_pollfds")]
+        private static extern IntPtr GetPollfdsInternal([In]MonoUsbSessionHandle sessionHandle);
+
         /// <summary>
         /// Register notification functions for file descriptor additions/removals. 
         /// </summary>
@@ -789,681 +819,8 @@ namespace MonoLibUsb
         /// <param name="removedDelegate">Function delegate for removal notifications.</param>
         /// <param name="pUserData">User data to be passed back to callbacks (useful for passing sessionHandle information).</param>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_set_pollfd_notifiers")]
-        public static extern void SetPollfdNotifiers([In]MonoUsbSessionHandle sessionHandle,
-                                                              PollfdAddedDelegate addedDelegate,
-                                                              PollfdRemovedDelegate removedDelegate,
-                                                              IntPtr pUserData);
-
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_pollfds")]
-        private static extern IntPtr GetPollfdsInternal([In]MonoUsbSessionHandle sessionHandle);
-
-        /// <summary>
-        /// Retrieve a list of file descriptors that should be polled by your main loop as libusb event sources. 
-        /// </summary>
-        /// <remarks>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="poll"/></note>
-        /// </remarks>
-        /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
-        /// <returns>A list of PollfdItem structures, or null on error.</returns>
-        public static List<PollfdItem> GetPollfds(MonoUsbSessionHandle sessionHandle)
-        {
-            List<PollfdItem> rtnList = new List<PollfdItem>();
-            IntPtr pList = GetPollfdsInternal(sessionHandle);
-            if (pList == IntPtr.Zero) return null;
-
-            IntPtr pNext = pList;
-            IntPtr pPollfd;
-            while ((((pNext != IntPtr.Zero))) && (pPollfd = Marshal.ReadIntPtr(pNext)) != IntPtr.Zero)
-            {
-                PollfdItem pollfdItem = new PollfdItem(pPollfd);
-                rtnList.Add(pollfdItem);
-                pNext = new IntPtr(pNext.ToInt64() + IntPtr.Size);
-            }
-            Marshal.FreeHGlobal(pList);
-
-            return rtnList;
-        }
+        public static extern void SetPollfdNotifiers([In]MonoUsbSessionHandle sessionHandle, PollfdAddedDelegate addedDelegate, PollfdRemovedDelegate removedDelegate, IntPtr pUserData);
 
         #endregion
-
-        #region API LIBRARY FUNCTIONS - Synchronous device I/O
-
-        /// <summary>
-        /// Perform a USB control transfer.
-        /// </summary>
-        /// <remarks>
-        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
-        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="requestType">The request type field for the setup packet.</param>
-        /// <param name="request">The request field for the setup packet.</param>
-        /// <param name="value">The value field for the setup packet</param>
-        /// <param name="index">The index field for the setup packet.</param>
-        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</param>
-        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
-        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>on success, the number of bytes actually transferred</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_control_transfer")]
-        public static extern int ControlTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                                         byte requestType,
-                                                         byte request,
-                                                         short value,
-                                                         short index,
-                                                         IntPtr pData,
-                                                         short dataLength,
-                                                         int timeout);
-
-
-        /// <summary>
-        /// Perform a USB control transfer for multi-threaded applications using the <see cref="MonoUsbEventHandler"/> class.
-        /// </summary>
-        /// <remarks>
-        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
-        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="requestType">The request type field for the setup packet.</param>
-        /// <param name="request">The request field for the setup packet.</param>
-        /// <param name="value">The value field for the setup packet</param>
-        /// <param name="index">The index field for the setup packet.</param>
-        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</param>
-        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
-        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>on success, the number of bytes actually transferred</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        public static int ControlTransferAsync([In] MonoUsbDeviceHandle deviceHandle,
-                                                 byte requestType,
-                                                 byte request,
-                                                 short value,
-                                                 short index,
-                                                 IntPtr pData,
-                                                 short dataLength,
-                                                 int timeout)
-        {
-            MonoUsbControlSetupHandle setupHandle = new MonoUsbControlSetupHandle(requestType, request, value, index, pData, dataLength);
-            MonoUsbTransfer transfer = new MonoUsbTransfer(0);
-            ManualResetEvent completeEvent = new ManualResetEvent(false);
-            GCHandle gcCompleteEvent = GCHandle.Alloc(completeEvent);
-
-            transfer.FillControl(deviceHandle, setupHandle, DefaultAsyncDelegate, GCHandle.ToIntPtr(gcCompleteEvent), timeout);
-
-            int r = (int)transfer.Submit();
-            if (r < 0)
-            {
-                transfer.Free();
-                gcCompleteEvent.Free();
-                return r;
-            }
-            IntPtr pSessionHandle;
-            MonoUsbSessionHandle sessionHandle = MonoUsbEventHandler.SessionHandle;
-            if (sessionHandle == null) 
-                pSessionHandle = IntPtr.Zero;
-            else
-                pSessionHandle = sessionHandle.DangerousGetHandle();
-
-            if (MonoUsbEventHandler.IsStopped)
-            {
-                while (!completeEvent.WaitOne(0))
-                {
-                    r = HandleEvents(pSessionHandle);
-                    if (r < 0)
-                    {
-                        if (r == (int)MonoUsbError.ErrorInterrupted)
-                            continue;
-                        transfer.Cancel();
-                        while (!completeEvent.WaitOne(0))
-                            if (HandleEvents(pSessionHandle) < 0)
-                                break;
-                        transfer.Free();
-                        gcCompleteEvent.Free();
-                        return r;
-                    }
-                }
-            }
-            else
-            {
-                completeEvent.WaitOne(Timeout.Infinite);
-            }
-
-            if (transfer.Status == MonoUsbTansferStatus.TransferCompleted)
-            {
-                r = transfer.ActualLength;
-                if (r > 0)
-                {
-                    byte[] ctrlDataBytes = setupHandle.ControlSetup.GetData(r);
-                    Marshal.Copy(ctrlDataBytes, 0, pData, Math.Min(ctrlDataBytes.Length, dataLength));
-                }
-
-            }
-            else
-                r = (int)MonoLibUsbErrorFromTransferStatus(transfer.Status);
-
-            transfer.Free();
-            gcCompleteEvent.Free();
-            return r;
-        }
-
-        /// <summary>
-        /// Perform a USB control transfer.
-        /// </summary>
-        /// <remarks>
-        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
-        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="requestType">The request type field for the setup packet.</param>
-        /// <param name="request">The request field for the setup packet.</param>
-        /// <param name="value">The value field for the setup packet</param>
-        /// <param name="index">The index field for the setup packet.</param>
-        /// <param name="data">
-        /// <para>A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</para>
-        /// This value can be:
-        /// <list type="bullet">
-        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
-        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
-        /// <item>An <see cref="IntPtr"/>.</item>
-        /// </list>
-        /// </param>
-        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
-        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>on success, the number of bytes actually transferred</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        public static int ControlTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                                  byte requestType,
-                                                  byte request,
-                                                  short value,
-                                                  short index,
-                                                  object data,
-                                                  short dataLength,
-                                                  int timeout)
-        {
-            PinnedHandle p = new PinnedHandle(data);
-            int ret = ControlTransfer(deviceHandle, requestType, request, value, index, p.Handle, dataLength, timeout);
-            p.Dispose();
-            return ret;
-        }
-
-#if NOT_USED
-    /// <summary>
-    /// Perform a USB control transfer.
-    /// </summary>
-    /// <remarks>
-    /// The direction of the transfer is inferred from the bmRequestType field of the setup packet. 
-    /// The wValue, wIndex and wLength fields values should be given in host-endian byte order.
-    /// </remarks>
-    /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-    /// <param name="setupPacket">The setup packet.</param>
-    /// <param name="pData">A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</param>
-    /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
-    /// <param name="timeout">timeout (in millseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-    /// <returns>on success, the number of bytes actually transferred, Other wise a <see cref="MonoUsbError"/>.</returns>
-        public static int libusb_control_transfer(MonoUsbDeviceHandle deviceHandle,
-                                                  ref libusb_control_setup setupPacket,
-                                                  IntPtr pData,
-                                                  short dataLength,
-                                                  int timeout)
-        {
-            return libusb_control_transfer(deviceHandle,
-                                           setupPacket.bmRequestType,
-                                           setupPacket.bRequest,
-                                           setupPacket.wValue,
-                                           setupPacket.wIndex,
-                                           pData,
-                                           dataLength,
-                                           timeout);
-        }
-#endif
-
-        /// <summary>
-        /// Perform a USB bulk transfer. 
-        /// </summary>
-        /// <remarks>
-        /// <para>The direction of the transfer is inferred from the direction bits of the endpoint address.</para>
-        /// <para>
-        /// For bulk reads, the length field indicates the maximum length of data you are expecting to receive.
-        /// If less data arrives than expected, this function will return that data, so be sure to check the 
-        /// transferred output parameter.
-        /// </para>
-        /// <para>
-        /// You should also check the transferred parameter for bulk writes. Not all of the data may have been 
-        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
-        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
-        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
-        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
-        /// of I/O.
-        /// </para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
-        /// <param name="pData">
-        /// A suitably-sized data buffer for either input or output (depending on endpoint).</param>
-        /// <param name="length">For bulk writes, the number of bytes from data to be sent. for bulk reads, the maximum number of bytes to receive into the data buffer.</param>
-        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
-        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
-        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_bulk_transfer")]
-        public static extern int BulkTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                                      byte endpoint,
-                                                      IntPtr pData,
-                                                      int length,
-                                                      out int actualLength,
-                                                      int timeout);
-
-        /// <summary>
-        /// Perform a USB bulk transfer. 
-        /// </summary>
-        /// <remarks>
-        /// <para>The direction of the transfer is inferred from the direction bits of the endpoint address.</para>
-        /// <para>
-        /// For bulk reads, the length field indicates the maximum length of data you are expecting to receive.
-        /// If less data arrives than expected, this function will return that data, so be sure to check the 
-        /// transferred output parameter.
-        /// </para>
-        /// <para>
-        /// You should also check the transferred parameter for bulk writes. Not all of the data may have been 
-        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
-        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
-        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
-        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
-        /// of I/O.
-        /// </para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
-        /// <param name="data">
-        /// <para>A suitably-sized data buffer for either input or output (depending on endpoint).</para>
-        /// This value can be:
-        /// <list type="bullet">
-        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
-        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
-        /// <item>An <see cref="IntPtr"/>.</item>
-        /// </list>
-        /// </param>
-        /// <param name="length">For bulk writes, the number of bytes from data to be sent. for bulk reads, the maximum number of bytes to receive into the data buffer.</param>
-        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
-        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
-        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        public static int BulkTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                               byte endpoint,
-                                               object data,
-                                               int length,
-                                               out int actualLength,
-                                               int timeout)
-        {
-            PinnedHandle p = new PinnedHandle(data);
-            int ret = BulkTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
-            p.Dispose();
-            return ret;
-        }
-
-        /// <summary>
-        /// Perform a USB interrupt transfer. 
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The direction of the transfer is inferred from the direction bits of the endpoint address.
-        /// </para><para>
-        /// For interrupt reads, the length field indicates the maximum length of data you are expecting to receive.
-        /// If less data arrives than expected, this function will return that data, so be sure to check the 
-        /// transferred output parameter.
-        /// </para><para>
-        /// You should also check the transferred parameter for interrupt writes. Not all of the data may have been 
-        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
-        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
-        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
-        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
-        /// of I/O.
-        /// </para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
-        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on endpoint).</param>
-        /// <param name="length">For interrupt writes, the number of bytes from data to be sent. for interrupt reads, the maximum number of bytes to receive into the data buffer.</param>
-        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
-        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
-        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_interrupt_transfer")]
-        public static extern int InterruptTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                                           byte endpoint,
-                                                           IntPtr pData,
-                                                           int length,
-                                                           out int actualLength,
-                                                           int timeout);
-
-
-        /// <summary>
-        /// Perform a USB interrupt transfer. 
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The direction of the transfer is inferred from the direction bits of the endpoint address.
-        /// </para><para>
-        /// For interrupt reads, the length field indicates the maximum length of data you are expecting to receive.
-        /// If less data arrives than expected, this function will return that data, so be sure to check the 
-        /// transferred output parameter.
-        /// </para><para>
-        /// You should also check the transferred parameter for interrupt writes. Not all of the data may have been 
-        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
-        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
-        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
-        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
-        /// of I/O.
-        /// </para>
-        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
-        /// </remarks>
-        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
-        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
-        /// <param name="data">
-        /// <para>A suitably-sized data buffer for either input or output (depending on endpoint).</para>
-        /// This value can be:
-        /// <list type="bullet">
-        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
-        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
-        /// <item>An <see cref="IntPtr"/>.</item>
-        /// </list>
-        /// </param>
-        /// <param name="length">For interrupt writes, the number of bytes from data to be sent. for interrupt reads, the maximum number of bytes to receive into the data buffer.</param>
-        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
-        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
-        /// <returns>
-        /// <list type="bullet">
-        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
-        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
-        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
-        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
-        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
-        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
-        /// </list>
-        /// </returns>
-        public static int InterruptTransfer([In] MonoUsbDeviceHandle deviceHandle,
-                                                    byte endpoint,
-                                                    object data,
-                                                    int length,
-                                                    out int actualLength,
-                                                    int timeout)
-        {
-            PinnedHandle p = new PinnedHandle(data);
-            int ret = InterruptTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
-            p.Dispose();
-            return ret;
-        }
-
-        #endregion
-
-        #region API LIBRARY FUNCTIONS - Misc
-
-        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_strerror")]
-        private static extern IntPtr StrError(int errcode);
-
-        /// <summary>
-        /// Get a string describing a <see cref="MonoUsbError"/>.
-        /// </summary>
-        /// <param name="errcode">The <see cref="MonoUsbError"/> code to retrieve a description for.</param>
-        /// <returns>A string describing the <see cref="MonoUsbError"/> code.</returns>
-        public static string StrError(MonoUsbError errcode)
-        {
-            switch (errcode)
-            {
-                case MonoUsbError.Success:
-                    return "Success";
-                case MonoUsbError.ErrorIO:
-                    return "Input/output error";
-                case MonoUsbError.ErrorInvalidParam:
-                    return "Invalid parameter";
-                case MonoUsbError.ErrorAccess:
-                    return "Access denied (insufficient permissions)";
-                case MonoUsbError.ErrorNoDevice:
-                    return "No such device (it may have been disconnected)";
-                case MonoUsbError.ErrorBusy:
-                    return "Resource busy";
-                case MonoUsbError.ErrorTimeout:
-                    return "Operation timed out";
-                case MonoUsbError.ErrorOverflow:
-                    return "Overflow";
-                case MonoUsbError.ErrorPipe:
-                    return "Pipe error or endpoint halted";
-                case MonoUsbError.ErrorInterrupted:
-                    return "System call interrupted (perhaps due to signal)";
-                case MonoUsbError.ErrorNoMem:
-                    return "Insufficient memory";
-                case MonoUsbError.ErrorIOCancelled:
-                    return "Transfer was canceled";
-                case MonoUsbError.ErrorNotSupported:
-                    return "Operation not supported or unimplemented on this platform";
-                default:
-                    return "Unknown error:" + errcode;
-            }
-        }
-
-        #endregion
-
-        #region API LIBRARY - Windows Testing Only
-#if WINDOWS_TESTING
-        internal static internal_windows_device_priv GetWindowsPriv(MonoUsbProfileHandle profileHandle)
-        {
-            internal_windows_device_priv priv = new internal_windows_device_priv();
-            IntPtr pPriv = new IntPtr(profileHandle.DangerousGetHandle().ToInt64() + Marshal.SizeOf(typeof(internal_libusb_device)));
-            Marshal.PtrToStructure(pPriv, priv);
-            return priv;
-        }
-
-        [StructLayout(LayoutKind.Sequential,Pack=0)]
-        internal class internal_libusb_device
-        {
-            public readonly IntPtr mutexLock;
-            public readonly int refCnt;                 /*QL - changed short to int*/
-
-            public readonly IntPtr ctx;
-
-            public readonly byte busNumber;
-            public readonly byte deviceAddress;
-            public readonly byte numConfigurations;
-
-            public readonly internal_list_head list = new internal_list_head();
-            public readonly uint sessionData;
-            //public readonly IntPtr temp;
-        }
-
-        [StructLayout(LayoutKind.Sequential, Pack = 0)]
-        internal class internal_list_head
-        {
-            public readonly IntPtr prev;
-            public readonly IntPtr next;
-        }
-
-        internal struct internal_usb_interface
-        {
-            public readonly IntPtr path;                    // each interface needs a Windows device interface path,
-            public readonly IntPtr apib;                    // an API backend (multiple drivers support),
-            public readonly byte nb_endpoints;              // and a set of endpoint addresses (USB_MAXENDPOINTS)
-            public readonly IntPtr endpoint;                /*QL - added */
-            public readonly bool restricted_functionality;  /*QL - added */         
-        }
-
-[StructLayout(LayoutKind.Sequential, Pack = 0)]
-        internal class internal_windows_device_priv
-        {
-            public readonly IntPtr parent_dev;     // access to parent is required for usermode ops
-            public readonly uint connection_index;  // also required for some usermode ops
-            public readonly IntPtr path;            // path used by Windows to reference the USB node
-
-            public readonly IntPtr apib;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public readonly internal_usb_interface[] usb_interfaces=new internal_usb_interface[32];
-
-            public readonly byte composite_api_flags;        // HID and composite devices require additional data
-            public readonly IntPtr hid;
-            public readonly byte active_config;
-
-            public readonly IntPtr dev_descriptor;       /*QL - added*/
-            public readonly IntPtr config_descriptor;    /*QL - added*/
-            //USB_DEVICE_DESCRIPTOR dev_descriptor;
-            //char **config_descriptor;  // list of pointers to the cached config descriptors
-        }
-#endif
-        #endregion
-
-        /// <summary>
-        /// Converts a <see cref="MonoUsbTansferStatus"/> enum to a <see cref="MonoUsbError"/> enum.
-        /// </summary>
-        /// <param name="status">the <see cref="MonoUsbTansferStatus"/> to convert.</param>
-        /// <returns>A <see cref="MonoUsbError"/> that represents <paramref name="status"/>.</returns>
-        public static MonoUsbError MonoLibUsbErrorFromTransferStatus(MonoUsbTansferStatus status)
-        {
-            switch (status)
-            {
-                case MonoUsbTansferStatus.TransferCompleted:
-                    return MonoUsbError.Success;
-                case MonoUsbTansferStatus.TransferError:
-                    return MonoUsbError.ErrorPipe;
-                case MonoUsbTansferStatus.TransferTimedOut:
-                    return MonoUsbError.ErrorTimeout;
-                case MonoUsbTansferStatus.TransferCancelled:
-                    return MonoUsbError.ErrorIOCancelled;
-                case MonoUsbTansferStatus.TransferStall:
-                    return MonoUsbError.ErrorPipe;
-                case MonoUsbTansferStatus.TransferNoDevice:
-                    return MonoUsbError.ErrorNoDevice;
-                case MonoUsbTansferStatus.TransferOverflow:
-                    return MonoUsbError.ErrorOverflow;
-                default:
-                    return MonoUsbError.ErrorOther;
-            }
-        }
-
-        /// <summary>
-        /// Calls <see cref="MonoUsbEventHandler.Init()"/> and <see cref="MonoUsbEventHandler.Start"/> if <see cref="MonoUsbEventHandler.IsStopped"/> = true.
-        /// </summary>
-        internal static void InitAndStart()
-        {
-            if (!MonoUsbEventHandler.IsStopped) return;
-            MonoUsbEventHandler.Init();
-            MonoUsbEventHandler.Start();
-        }
-
-        /// <summary>
-        /// Calls <see cref="MonoUsbEventHandler.Stop"/> and <see cref="MonoUsbEventHandler.Exit"/>.
-        /// </summary>
-        internal static void StopAndExit()
-        {
-#if LIBUSBDOTNET
-            if (LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList != null) LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList.Close();
-            LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList = null;
-#endif
-            MonoUsbEventHandler.Stop(true);
-            MonoUsbEventHandler.Exit();
-        }
-
-
-#if LIBUSBDOTNET
-        internal static ErrorCode ErrorCodeFromLibUsbError(int ret, out string description)
-        {
-            description = string.Empty;
-            if (ret == 0) return ErrorCode.Success;
-
-            switch ((MonoUsbError) ret)
-            {
-                case MonoUsbError.Success:
-                    description += "Success";
-                    return ErrorCode.Success;
-                case MonoUsbError.ErrorIO:
-                    description += "Input/output error";
-                    return ErrorCode.IoSyncFailed;
-                case MonoUsbError.ErrorInvalidParam:
-                    description += "Invalid parameter";
-                    return ErrorCode.InvalidParam;
-                case MonoUsbError.ErrorAccess:
-                    description += "Access denied (insufficient permissions)";
-                    return ErrorCode.AccessDenied;
-                case MonoUsbError.ErrorNoDevice:
-                    description += "No such device (it may have been disconnected)";
-                    return ErrorCode.DeviceNotFound;
-                case MonoUsbError.ErrorBusy:
-                    description += "Resource busy";
-                    return ErrorCode.ResourceBusy;
-                case MonoUsbError.ErrorTimeout:
-                    description += "Operation timed out";
-                    return ErrorCode.IoTimedOut;
-                case MonoUsbError.ErrorOverflow:
-                    description += "Overflow";
-                    return ErrorCode.Overflow;
-                case MonoUsbError.ErrorPipe:
-                    description += "Pipe error or endpoint halted";
-                    return ErrorCode.PipeError;
-                case MonoUsbError.ErrorInterrupted:
-                    description += "System call interrupted (perhaps due to signal)";
-                    return ErrorCode.Interrupted;
-                case MonoUsbError.ErrorNoMem:
-                    description += "Insufficient memory";
-                    return ErrorCode.InsufficientMemory;
-                case MonoUsbError.ErrorIOCancelled:
-                    description += "Transfer was canceled";
-                    return ErrorCode.IoCancelled;
-                case MonoUsbError.ErrorNotSupported:
-                    description += "Operation not supported or unimplemented on this platform";
-                    return ErrorCode.NotSupported;
-                default:
-                    description += "Unknown error:" + ret;
-                    return ErrorCode.UnknownError;
-            }
-        }
-#endif
     }
 }

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
@@ -1,0 +1,593 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using LibUsbDotNet.Main;
+using MonoLibUsb.Profile;
+using MonoLibUsb.Transfer;
+
+namespace MonoLibUsb
+{
+    public static partial class MonoUsbApi
+    {
+        internal const int LIBUSB_PACK = 0;
+
+        #region Private Members
+
+        private static readonly MonoUsbTransferDelegate DefaultAsyncDelegate = DefaultAsyncCB;
+        private static void DefaultAsyncCB(MonoUsbTransfer transfer)
+        {
+            ManualResetEvent completeEvent = GCHandle.FromIntPtr(transfer.PtrUserData).Target as ManualResetEvent;
+            completeEvent.Set();
+        }
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Error Handling
+        /// <summary>
+        /// Get a string describing a <see cref="MonoUsbError"/>.
+        /// </summary>
+        /// <param name="errcode">The <see cref="MonoUsbError"/> code to retrieve a description for.</param>
+        /// <returns>A string describing the <see cref="MonoUsbError"/> code.</returns>
+        public static string StrError(MonoUsbError errcode)
+        {
+            switch (errcode)
+            {
+                case MonoUsbError.Success:
+                    return "Success";
+                case MonoUsbError.ErrorIO:
+                    return "Input/output error";
+                case MonoUsbError.ErrorInvalidParam:
+                    return "Invalid parameter";
+                case MonoUsbError.ErrorAccess:
+                    return "Access denied (insufficient permissions)";
+                case MonoUsbError.ErrorNoDevice:
+                    return "No such device (it may have been disconnected)";
+                case MonoUsbError.ErrorBusy:
+                    return "Resource busy";
+                case MonoUsbError.ErrorTimeout:
+                    return "Operation timed out";
+                case MonoUsbError.ErrorOverflow:
+                    return "Overflow";
+                case MonoUsbError.ErrorPipe:
+                    return "Pipe error or endpoint halted";
+                case MonoUsbError.ErrorInterrupted:
+                    return "System call interrupted (perhaps due to signal)";
+                case MonoUsbError.ErrorNoMem:
+                    return "Insufficient memory";
+                case MonoUsbError.ErrorIOCancelled:
+                    return "Transfer was canceled";
+                case MonoUsbError.ErrorNotSupported:
+                    return "Operation not supported or unimplemented on this platform";
+                default:
+                    return "Unknown error:" + errcode;
+            }
+        }
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - USB descriptors
+
+        /// <summary>
+        /// Retrieve a descriptor from the default control pipe. 
+        /// </summary>
+        /// <remarks>
+        /// <para>This is a convenience function which formulates the appropriate control message to retrieve the descriptor.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">Retrieve a descriptor from the default control pipe.</param>
+        /// <param name="descType">The descriptor type, <see cref="DescriptorType"/></param>
+        /// <param name="descIndex">The index of the descriptor to retrieve.</param>
+        /// <param name="pData">Output buffer for descriptor.</param>
+        /// <param name="length">Size of data buffer.</param>
+        /// <returns>Number of bytes returned in data, or a <see cref="MonoUsbError"/> code on failure.</returns>
+        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, IntPtr pData, int length)
+        {
+            return ControlTransfer(deviceHandle,
+                                           (byte)UsbEndpointDirection.EndpointIn,
+                                           (byte)UsbStandardRequest.GetDescriptor,
+                                           (short)((descType << 8) | descIndex),
+                                           0,
+                                           pData,
+                                           (short)length,
+                                           1000);
+        }
+
+        /// <summary>
+        /// Retrieve a descriptor from the default control pipe. 
+        /// </summary>
+        /// <remarks>
+        /// <para>This is a convenience function which formulates the appropriate control message to retrieve the descriptor.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="desc"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">Retrieve a descriptor from the default control pipe.</param>
+        /// <param name="descType">The descriptor type, <see cref="DescriptorType"/></param>
+        /// <param name="descIndex">The index of the descriptor to retrieve.</param>
+        /// <param name="data">Output buffer for descriptor. This object is pinned using <see cref="PinnedHandle"/>.</param>
+        /// <param name="length">Size of data buffer.</param>
+        /// <returns>Number of bytes returned in data, or <see cref="MonoUsbError"/> code on failure.</returns>
+        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, object data, int length)
+        {
+            PinnedHandle p = new PinnedHandle(data);
+            return GetDescriptor(deviceHandle, descType, descIndex, p.Handle, length);
+        }
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Device handling and enumeration (part 2)
+
+        /// <summary>
+        /// Convenience function for finding a device with a particular idVendor/idProduct combination. 
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
+        /// </remarks>
+        /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
+        /// <param name="vendorID">The idVendor value to search for.</param>
+        /// <param name="productID">The idProduct value to search for.</param>
+        /// <returns>Null if the device was not opened or not found, otherwise an opened device handle.</returns>
+        public static MonoUsbDeviceHandle OpenDeviceWithVidPid([In]MonoUsbSessionHandle sessionHandle, short vendorID, short productID)
+        {
+            IntPtr pHandle = OpenDeviceWithVidPidInternal(sessionHandle, vendorID, productID);
+            if (pHandle == IntPtr.Zero) return null;
+            return new MonoUsbDeviceHandle(pHandle);
+        }
+
+        /// <summary>
+        /// Get a <see cref="MonoUsbProfileHandle"/> for a <see cref="MonoUsbDeviceHandle"/>. 
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This function differs from the Libusb-1.0 C API in that when the new <see cref="MonoUsbProfileHandle"/> is returned, the device profile reference count 
+        /// is incremented ensuring the profile will remain valid as long as it is in-use.
+        /// </para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
+        /// </remarks>
+        /// <param name="devicehandle">A device handle.</param>
+        /// <returns>The underlying profile handle.</returns>
+        public static MonoUsbProfileHandle GetDevice(MonoUsbDeviceHandle devicehandle) { return new MonoUsbProfileHandle(GetDeviceInternal(devicehandle)); }
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Synchronous device I/O
+
+        /// <summary>
+        /// Perform a USB bulk transfer. 
+        /// </summary>
+        /// <remarks>
+        /// <para>The direction of the transfer is inferred from the direction bits of the endpoint address.</para>
+        /// <para>
+        /// For bulk reads, the length field indicates the maximum length of data you are expecting to receive.
+        /// If less data arrives than expected, this function will return that data, so be sure to check the 
+        /// transferred output parameter.
+        /// </para>
+        /// <para>
+        /// You should also check the transferred parameter for bulk writes. Not all of the data may have been 
+        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
+        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
+        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
+        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
+        /// of I/O.
+        /// </para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
+        /// <param name="data">
+        /// <para>A suitably-sized data buffer for either input or output (depending on endpoint).</para>
+        /// This value can be:
+        /// <list type="bullet">
+        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
+        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
+        /// <item>An <see cref="IntPtr"/>.</item>
+        /// </list>
+        /// </param>
+        /// <param name="length">For bulk writes, the number of bytes from data to be sent. for bulk reads, the maximum number of bytes to receive into the data buffer.</param>
+        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
+        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
+        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        public static int BulkTransfer([In] MonoUsbDeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
+        {
+            PinnedHandle p = new PinnedHandle(data);
+            int ret = BulkTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
+            p.Dispose();
+            return ret;
+        }
+
+        /// <summary>
+        /// Perform a USB interrupt transfer. 
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The direction of the transfer is inferred from the direction bits of the endpoint address.
+        /// </para><para>
+        /// For interrupt reads, the length field indicates the maximum length of data you are expecting to receive.
+        /// If less data arrives than expected, this function will return that data, so be sure to check the 
+        /// transferred output parameter.
+        /// </para><para>
+        /// You should also check the transferred parameter for interrupt writes. Not all of the data may have been 
+        /// written. Also check transferred when dealing with a timeout error code. libusb may have to split 
+        /// your transfer into a number of chunks to satisfy underlying O/S requirements, meaning that the 
+        /// timeout may expire after the first few chunks have completed. libusb is careful not to lose any 
+        /// data that may have been transferred; do not assume that timeout conditions indicate a complete lack 
+        /// of I/O.
+        /// </para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="endpoint">The address of a valid endpoint to communicate with.</param>
+        /// <param name="data">
+        /// <para>A suitably-sized data buffer for either input or output (depending on endpoint).</para>
+        /// This value can be:
+        /// <list type="bullet">
+        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
+        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
+        /// <item>An <see cref="IntPtr"/>.</item>
+        /// </list>
+        /// </param>
+        /// <param name="length">For interrupt writes, the number of bytes from data to be sent. for interrupt reads, the maximum number of bytes to receive into the data buffer.</param>
+        /// <param name="actualLength">Output location for the number of bytes actually transferred.</param>
+        /// <param name="timeout">Timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>0 on success (and populates <paramref name="actualLength"/>)</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the endpoint halted</item>
+        /// <item><see cref="MonoUsbError.ErrorOverflow"/>if the device offered more data, see <a href="http://libusb.sourceforge.net/api-1.0/packetoverflow.html">Packets and overflows</a></item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        public static int InterruptTransfer([In] MonoUsbDeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
+        {
+            PinnedHandle p = new PinnedHandle(data);
+            int ret = InterruptTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
+            p.Dispose();
+            return ret;
+        }
+
+        /// <summary>
+        /// Perform a USB control transfer for multi-threaded applications using the <see cref="MonoUsbEventHandler"/> class.
+        /// </summary>
+        /// <remarks>
+        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
+        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="requestType">The request type field for the setup packet.</param>
+        /// <param name="request">The request field for the setup packet.</param>
+        /// <param name="value">The value field for the setup packet</param>
+        /// <param name="index">The index field for the setup packet.</param>
+        /// <param name="pData">A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</param>
+        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
+        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>on success, the number of bytes actually transferred</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        public static int ControlTransferAsync([In] MonoUsbDeviceHandle deviceHandle, byte requestType, byte request, short value, short index, IntPtr pData, short dataLength, int timeout)
+        {
+            MonoUsbControlSetupHandle setupHandle = new MonoUsbControlSetupHandle(requestType, request, value, index, pData, dataLength);
+            MonoUsbTransfer transfer = new MonoUsbTransfer(0);
+            ManualResetEvent completeEvent = new ManualResetEvent(false);
+            GCHandle gcCompleteEvent = GCHandle.Alloc(completeEvent);
+
+            transfer.FillControl(deviceHandle, setupHandle, DefaultAsyncDelegate, GCHandle.ToIntPtr(gcCompleteEvent), timeout);
+
+            int r = (int)transfer.Submit();
+            if (r < 0)
+            {
+                transfer.Free();
+                gcCompleteEvent.Free();
+                return r;
+            }
+            IntPtr pSessionHandle;
+            MonoUsbSessionHandle sessionHandle = MonoUsbEventHandler.SessionHandle;
+            if (sessionHandle == null)
+                pSessionHandle = IntPtr.Zero;
+            else
+                pSessionHandle = sessionHandle.DangerousGetHandle();
+
+            if (MonoUsbEventHandler.IsStopped)
+            {
+                while (!completeEvent.WaitOne(0))
+                {
+                    r = HandleEvents(pSessionHandle);
+                    if (r < 0)
+                    {
+                        if (r == (int)MonoUsbError.ErrorInterrupted)
+                            continue;
+                        transfer.Cancel();
+                        while (!completeEvent.WaitOne(0))
+                            if (HandleEvents(pSessionHandle) < 0)
+                                break;
+                        transfer.Free();
+                        gcCompleteEvent.Free();
+                        return r;
+                    }
+                }
+            }
+            else
+            {
+                completeEvent.WaitOne(Timeout.Infinite);
+            }
+
+            if (transfer.Status == MonoUsbTansferStatus.TransferCompleted)
+            {
+                r = transfer.ActualLength;
+                if (r > 0)
+                {
+                    byte[] ctrlDataBytes = setupHandle.ControlSetup.GetData(r);
+                    Marshal.Copy(ctrlDataBytes, 0, pData, Math.Min(ctrlDataBytes.Length, dataLength));
+                }
+
+            }
+            else
+                r = (int)MonoLibUsbErrorFromTransferStatus(transfer.Status);
+
+            transfer.Free();
+            gcCompleteEvent.Free();
+            return r;
+        }
+
+        /// <summary>
+        /// Perform a USB control transfer.
+        /// </summary>
+        /// <remarks>
+        /// <para>The direction of the transfer is inferred from the bmRequestType field of the setup packet.</para>
+        /// <para>The wValue, wIndex and wLength fields values should be given in host-endian byte order.</para>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="syncio"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A handle for the device to communicate with.</param>
+        /// <param name="requestType">The request type field for the setup packet.</param>
+        /// <param name="request">The request field for the setup packet.</param>
+        /// <param name="value">The value field for the setup packet</param>
+        /// <param name="index">The index field for the setup packet.</param>
+        /// <param name="data">
+        /// <para>A suitably-sized data buffer for either input or output (depending on direction bits within bmRequestType).</para>
+        /// This value can be:
+        /// <list type="bullet">
+        /// <item>An <see cref="Array"/> of bytes or other <a href="http://msdn.microsoft.com/en-us/library/75dwhxf7.aspx">blittable</a> types.</item>
+        /// <item>An already allocated, pinned <see cref="GCHandle"/>. In this case <see cref="GCHandle.AddrOfPinnedObject"/> is used for the buffer address.</item>
+        /// <item>An <see cref="IntPtr"/>.</item>
+        /// </list>
+        /// </param>
+        /// <param name="dataLength">The length field for the setup packet. The data buffer should be at least this size.</param>
+        /// <param name="timeout">timeout (in milliseconds) that this function should wait before giving up due to no response being received. For an unlimited timeout, use value 0.</param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item>on success, the number of bytes actually transferred</item>
+        /// <item><see cref="MonoUsbError.ErrorTimeout"/> if the transfer timed out</item>
+        /// <item><see cref="MonoUsbError.ErrorPipe"/> if the control request was not supported by the device.</item>
+        /// <item><see cref="MonoUsbError.ErrorNoDevice"/> if the device has been disconnected</item>
+        /// <item>another <see cref="MonoUsbError"/> code on other failures</item>
+        /// </list>
+        /// </returns>
+        public static int ControlTransfer([In] MonoUsbDeviceHandle deviceHandle, byte requestType, byte request, short value, short index, object data, short dataLength, int timeout)
+        {
+            PinnedHandle p = new PinnedHandle(data);
+            int ret = ControlTransfer(deviceHandle, requestType, request, value, index, p.Handle, dataLength, timeout);
+            p.Dispose();
+            return ret;
+        }
+
+        #endregion
+
+        #region API LIBRARY FUNCTIONS - Polling and timing
+
+        /// <summary>
+        /// Retrieve a list of file descriptors that should be polled by your main loop as libusb event sources. 
+        /// </summary>
+        /// <remarks>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="poll"/></note>
+        /// </remarks>
+        /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
+        /// <returns>A list of PollfdItem structures, or null on error.</returns>
+        public static List<PollfdItem> GetPollfds(MonoUsbSessionHandle sessionHandle)
+        {
+            List<PollfdItem> rtnList = new List<PollfdItem>();
+            IntPtr pList = GetPollfdsInternal(sessionHandle);
+            if (pList == IntPtr.Zero) return null;
+
+            IntPtr pNext = pList;
+            IntPtr pPollfd;
+            while ((((pNext != IntPtr.Zero))) && (pPollfd = Marshal.ReadIntPtr(pNext)) != IntPtr.Zero)
+            {
+                PollfdItem pollfdItem = new PollfdItem(pPollfd);
+                rtnList.Add(pollfdItem);
+                pNext = new IntPtr(pNext.ToInt64() + IntPtr.Size);
+            }
+            Marshal.FreeHGlobal(pList);
+
+            return rtnList;
+        }
+
+        #endregion
+
+
+        #region API LIBRARY - Windows Testing Only
+#if WINDOWS_TESTING
+        internal static internal_windows_device_priv GetWindowsPriv(MonoUsbProfileHandle profileHandle)
+        {
+            internal_windows_device_priv priv = new internal_windows_device_priv();
+            IntPtr pPriv = new IntPtr(profileHandle.DangerousGetHandle().ToInt64() + Marshal.SizeOf(typeof(internal_libusb_device)));
+            Marshal.PtrToStructure(pPriv, priv);
+            return priv;
+        }
+
+        [StructLayout(LayoutKind.Sequential,Pack=0)]
+        internal class internal_libusb_device
+        {
+            public readonly IntPtr mutexLock;
+            public readonly int refCnt;                 /*QL - changed short to int*/
+
+            public readonly IntPtr ctx;
+
+            public readonly byte busNumber;
+            public readonly byte deviceAddress;
+            public readonly byte numConfigurations;
+
+            public readonly internal_list_head list = new internal_list_head();
+            public readonly uint sessionData;
+            //public readonly IntPtr temp;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 0)]
+        internal class internal_list_head
+        {
+            public readonly IntPtr prev;
+            public readonly IntPtr next;
+        }
+
+        internal struct internal_usb_interface
+        {
+            public readonly IntPtr path;                    // each interface needs a Windows device interface path,
+            public readonly IntPtr apib;                    // an API backend (multiple drivers support),
+            public readonly byte nb_endpoints;              // and a set of endpoint addresses (USB_MAXENDPOINTS)
+            public readonly IntPtr endpoint;                /*QL - added */
+            public readonly bool restricted_functionality;  /*QL - added */         
+        }
+
+[StructLayout(LayoutKind.Sequential, Pack = 0)]
+        internal class internal_windows_device_priv
+        {
+            public readonly IntPtr parent_dev;     // access to parent is required for usermode ops
+            public readonly uint connection_index;  // also required for some usermode ops
+            public readonly IntPtr path;            // path used by Windows to reference the USB node
+
+            public readonly IntPtr apib;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            public readonly internal_usb_interface[] usb_interfaces=new internal_usb_interface[32];
+
+            public readonly byte composite_api_flags;        // HID and composite devices require additional data
+            public readonly IntPtr hid;
+            public readonly byte active_config;
+
+            public readonly IntPtr dev_descriptor;       /*QL - added*/
+            public readonly IntPtr config_descriptor;    /*QL - added*/
+            //USB_DEVICE_DESCRIPTOR dev_descriptor;
+            //char **config_descriptor;  // list of pointers to the cached config descriptors
+        }
+#endif
+        #endregion
+
+        /// <summary>
+        /// Converts a <see cref="MonoUsbTansferStatus"/> enum to a <see cref="MonoUsbError"/> enum.
+        /// </summary>
+        /// <param name="status">the <see cref="MonoUsbTansferStatus"/> to convert.</param>
+        /// <returns>A <see cref="MonoUsbError"/> that represents <paramref name="status"/>.</returns>
+        public static MonoUsbError MonoLibUsbErrorFromTransferStatus(MonoUsbTansferStatus status)
+        {
+            switch (status)
+            {
+                case MonoUsbTansferStatus.TransferCompleted:
+                    return MonoUsbError.Success;
+                case MonoUsbTansferStatus.TransferError:
+                    return MonoUsbError.ErrorPipe;
+                case MonoUsbTansferStatus.TransferTimedOut:
+                    return MonoUsbError.ErrorTimeout;
+                case MonoUsbTansferStatus.TransferCancelled:
+                    return MonoUsbError.ErrorIOCancelled;
+                case MonoUsbTansferStatus.TransferStall:
+                    return MonoUsbError.ErrorPipe;
+                case MonoUsbTansferStatus.TransferNoDevice:
+                    return MonoUsbError.ErrorNoDevice;
+                case MonoUsbTansferStatus.TransferOverflow:
+                    return MonoUsbError.ErrorOverflow;
+                default:
+                    return MonoUsbError.ErrorOther;
+            }
+        }
+
+        /// <summary>
+        /// Calls <see cref="MonoUsbEventHandler.Init()"/> and <see cref="MonoUsbEventHandler.Start"/> if <see cref="MonoUsbEventHandler.IsStopped"/> = true.
+        /// </summary>
+        internal static void InitAndStart()
+        {
+            if (!MonoUsbEventHandler.IsStopped) return;
+            MonoUsbEventHandler.Init();
+            MonoUsbEventHandler.Start();
+        }
+
+        /// <summary>
+        /// Calls <see cref="MonoUsbEventHandler.Stop"/> and <see cref="MonoUsbEventHandler.Exit"/>.
+        /// </summary>
+        internal static void StopAndExit()
+        {
+#if LIBUSBDOTNET
+            if (LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList != null) LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList.Close();
+            LibUsbDotNet.LudnMonoLibUsb.MonoUsbDevice.mMonoUSBProfileList = null;
+#endif
+            MonoUsbEventHandler.Stop(true);
+            MonoUsbEventHandler.Exit();
+        }
+
+#if LIBUSBDOTNET
+        internal static ErrorCode ErrorCodeFromLibUsbError(int ret, out string description)
+        {
+            description = string.Empty;
+            if (ret == 0) return ErrorCode.Success;
+
+            switch ((MonoUsbError)ret)
+            {
+                case MonoUsbError.Success:
+                    description += "Success";
+                    return ErrorCode.Success;
+                case MonoUsbError.ErrorIO:
+                    description += "Input/output error";
+                    return ErrorCode.IoSyncFailed;
+                case MonoUsbError.ErrorInvalidParam:
+                    description += "Invalid parameter";
+                    return ErrorCode.InvalidParam;
+                case MonoUsbError.ErrorAccess:
+                    description += "Access denied (insufficient permissions)";
+                    return ErrorCode.AccessDenied;
+                case MonoUsbError.ErrorNoDevice:
+                    description += "No such device (it may have been disconnected)";
+                    return ErrorCode.DeviceNotFound;
+                case MonoUsbError.ErrorBusy:
+                    description += "Resource busy";
+                    return ErrorCode.ResourceBusy;
+                case MonoUsbError.ErrorTimeout:
+                    description += "Operation timed out";
+                    return ErrorCode.IoTimedOut;
+                case MonoUsbError.ErrorOverflow:
+                    description += "Overflow";
+                    return ErrorCode.Overflow;
+                case MonoUsbError.ErrorPipe:
+                    description += "Pipe error or endpoint halted";
+                    return ErrorCode.PipeError;
+                case MonoUsbError.ErrorInterrupted:
+                    description += "System call interrupted (perhaps due to signal)";
+                    return ErrorCode.Interrupted;
+                case MonoUsbError.ErrorNoMem:
+                    description += "Insufficient memory";
+                    return ErrorCode.InsufficientMemory;
+                case MonoUsbError.ErrorIOCancelled:
+                    description += "Transfer was canceled";
+                    return ErrorCode.IoCancelled;
+                case MonoUsbError.ErrorNotSupported:
+                    description += "Operation not supported or unimplemented on this platform";
+                    return ErrorCode.NotSupported;
+                default:
+                    description += "Unknown error:" + ret;
+                    return ErrorCode.UnknownError;
+            }
+        }
+#endif
+    }
+}

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbCapability.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbCapability.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MonoLibUsb
+{
+    public enum MonoUsbCapability
+    {
+        /// <summary>
+        /// The libusb_has_capability() API is available.
+        /// </summary>
+        LIBUSB_CAP_HAS_CAPABILITY = 0x0000,
+        /// <summary>
+        /// Hotplug support is available on this platform.
+        /// </summary>
+	    LIBUSB_CAP_HAS_HOTPLUG = 0x0001,
+        /// <summary>
+        /// The library can access HID devices without requiring user intervention. 
+        /// Note that before being able to actually access an HID device, you may still have to call additional libusb functions such as libusb_detach_kernel_driver(). 
+        /// </summary>
+        LIBUSB_CAP_HAS_HID_ACCESS = 0x0100,
+        /// <summary>
+        /// The library supports detaching of the default USB driver, using libusb_detach_kernel_driver(), if one is set by the OS kernel
+        /// </summary>
+        LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER = 0x0101
+    }    
+}

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbCapability.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbCapability.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace MonoLibUsb
+﻿namespace MonoLibUsb
 {
     public enum MonoUsbCapability
     {

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbVersion.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbVersion.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.InteropServices;
+
+namespace MonoLibUsb.Descriptors
+{
+    [StructLayout(LayoutKind.Sequential, Pack = MonoUsbApi.LIBUSB_PACK)]
+    public class MonoUsbVersion
+    {
+        internal MonoUsbVersion()
+        {
+        }
+
+        public readonly int Major;
+
+        public readonly int Minor;
+
+        public readonly int Micro;
+
+        public readonly int Nano;
+
+        public readonly int RC;
+    }
+}


### PR DESCRIPTION
Separated the API DllImport method definitions from the other helper method for libusb. Also reordered them to match the original order in the C++ header, libusb.h.
Here is the complete list of the method signatures: https://docs.google.com/spreadsheets/d/1sNY7vqtrPs3n6b5w8joHh-KPzfnkQRmX5EacvzP9mic/edit?usp=sharing

Added 4 new methods and their structures to the method headers. They are not tested yet. Which testing framework would you guys prefer? NUnit or xUnit? xUnit needs .NET Framework 4.5 or Core, not sure about NUnit.

I also added the LGPLv3 license to the repo in a standardized way, plus added two badges to the main readme.md.